### PR TITLE
Add sacrifice for sl4y in return

### DIFF
--- a/src/config/index.tsx
+++ b/src/config/index.tsx
@@ -9,6 +9,8 @@ export const SLAYER_WALLET =
   process.env.SLAYER_WALLET ?? "0x3665eD160eDD2bC236fBDA83274eacA08769B0b9";
 export const SLAYER_CONTRACT =
   process.env.SLAYER_CONTRACT ?? "0x84466753b03e2f6d74afe8bf356c09e63dd36d67";
+export const SLAYER_MINT_CONTRACT =
+  process.env.SLAYER_MINT_CONTRACT ?? "0x335499b76Cf2A8A6e58717d62501218bB7862FcC";
 export const SLAYER_IMAGE_URL =
   process.env.SLAYER_IMAGE_URL ??
   "https://4wz7nuijhm67qgxnqw54egbv52zocgq3qei3gbb7la5vuvowh47q.arweave.net/5bP20Qk7Pfga7YW7whg17rLhGhuBEbMEP1g7WlXWPz8/";

--- a/src/config/index.tsx
+++ b/src/config/index.tsx
@@ -3,8 +3,6 @@ export const WALLET_CONNECT_PROJECT_ID =
 export const NETWORK = (process.env.NETWORK ?? "main") as "main" | "test";
 export const NODE_URL =
   process.env.NODE_URL ?? `https://node-${NETWORK}net.vechain.energy`;
-export const SPONSORSHIP_URL =
-  process.env.SPONSORSHIP_URL ?? "https://sponsor-testnet.vechain.energy/by/90";
 export const SLAYER_WALLET =
   process.env.SLAYER_WALLET ?? "0x3665eD160eDD2bC236fBDA83274eacA08769B0b9";
 export const SLAYER_CONTRACT =

--- a/src/pages/Altar.tsx
+++ b/src/pages/Altar.tsx
@@ -7,7 +7,7 @@ import {
   SelectContent,
   Select,
 } from "@/components/ui/select";
-import { useConnex } from "@vechain/dapp-kit-react";
+import { useConnex, useWallet } from "@vechain/dapp-kit-react";
 import { SLAYER_WALLET, SLAYER_MINT_CONTRACT, SPONSORSHIP_URL, NETWORK } from "@/config/index";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faCopy, faMagnifyingGlass } from "@fortawesome/free-solid-svg-icons";
@@ -16,6 +16,7 @@ import { useToast } from "@/components/ui/use-toast";
 
 export default function AltarPage() {
   const connex = useConnex();
+  const { account } = useWallet();
   const { toast } = useToast();
 
   const [selectedValue, setSelectedValue] = React.useState(1);
@@ -86,6 +87,7 @@ export default function AltarPage() {
         ])
         .delegate(SPONSORSHIP_URL)
         .comment(`Offering to the treasury of ${selectedValue} VTHO)`)
+        .signer(account)
         .request();
 
       setTxId(txid);

--- a/src/pages/Altar.tsx
+++ b/src/pages/Altar.tsx
@@ -8,7 +8,7 @@ import {
   Select,
 } from "@/components/ui/select";
 import { useConnex, useWallet } from "@vechain/dapp-kit-react";
-import { SLAYER_WALLET, SLAYER_MINT_CONTRACT, SPONSORSHIP_URL, NETWORK } from "@/config/index";
+import { SLAYER_WALLET, SLAYER_MINT_CONTRACT, NETWORK } from "@/config/index";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faCopy, faMagnifyingGlass } from "@fortawesome/free-solid-svg-icons";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -85,7 +85,6 @@ export default function AltarPage() {
             comment: `Sacrifice ${selectedValue} VTHO for SL4Y`
           }
         ])
-        .delegate(SPONSORSHIP_URL)
         .comment(`Offering to the treasury of ${selectedValue} VTHO)`)
         .signer(account)
         .request();

--- a/src/pages/Altar.tsx
+++ b/src/pages/Altar.tsx
@@ -186,7 +186,6 @@ export default function AltarPage() {
               <SelectValue placeholder="Make An Offering" />
             </SelectTrigger>
             <SelectContent position="item-aligned">
-              <SelectItem value="1">1 VTHO</SelectItem>
               <SelectItem value="5000">5,000 VTHO</SelectItem>
               <SelectItem value="10000">10,000 VTHO</SelectItem>
               <SelectItem value="15000">15,000 VTHO</SelectItem>

--- a/src/pages/Altar.tsx
+++ b/src/pages/Altar.tsx
@@ -185,6 +185,7 @@ export default function AltarPage() {
             </SelectTrigger>
             <SelectContent position="item-aligned">
               <SelectItem value="1">1 VTHO</SelectItem>
+              <SelectItem value="5000">5,000 VTHO</SelectItem>
               <SelectItem value="10000">10,000 VTHO</SelectItem>
               <SelectItem value="15000">15,000 VTHO</SelectItem>
               <SelectItem value="25000">25,000 VTHO</SelectItem>


### PR DESCRIPTION
- This PR adds a new environment variable called `SLAYER_MINT_CONTRACT`, defaulting to the currently known main net deployment.
- The Altar will now use a multi-clause transaction use the VTHO-TO-SL4Y contract, by granting it access to the selected VTHO amount and then calling the swap function.
- Update VTHO amount on altar to show only supported amounts
- Enforce currently signed in account for sacrifice, to remove potential user issues
- Remove fee delegation for transactions